### PR TITLE
Fix - Input Register returns incorrect data

### DIFF
--- a/src/CSE_ModbusRTU.cpp
+++ b/src/CSE_ModbusRTU.cpp
@@ -1156,7 +1156,7 @@ int CSE_ModbusRTU_Server:: poll() {
       // Read the register data from the input registers and write them to the array
       for (int i = request.getStartingAddress(), j = 0; i < (request.getStartingAddress() + request.getQuantity()); i++) {
         for (int k = 0; k < inputRegisters.size(); k++) {
-          if (holdingRegisters [k].address == i) {
+          if (inputRegisters [k].address == i) {
             inputRegisterData [j] = inputRegisters [k].value >> 8; // Get the high byte
             inputRegisterData [j + 1] = inputRegisters [k].value & 0xFF; // Get the low byte
             j += 2;


### PR DESCRIPTION
When reading input registers, incorrect data was returned.

Using the example code `Holding_Regsiter_Server.ino`, and replacing the HoldingRegister functions with InputRegister functions shows this behaviour

I found an incorrect variable name on line 1159 - updating the variable name to inputRegisters fixes the issue - I have tested this, albeit on an STM32 Nucleo board instead of any of the officially supported platforms